### PR TITLE
Fix: Precisely target user's own replies for deletion

### DIFF
--- a/XDel.py
+++ b/XDel.py
@@ -458,7 +458,7 @@ class XItemDeleter:
 
                     found_user_reply_cell = None
                     for cell in potential_reply_cells:
-                        try
+                        try:
                             # Check if this cell directly contains the user's profile link and is visible.
                             # This helps ensure it's the user's actual reply content.
                             user_link = cell.find_element(By.XPATH, f".//a[@href='/{username}' and @role='link'][.//span[contains(text(), '@{username}')]]")


### PR DESCRIPTION
Also, corrects a SyntaxError (missing colon after 'try') introduced in the previous attempt to refine reply deletion logic.

The previous implementation could inadvertently click the '...' menu on any post when processing the replies page.

This change refines the `delete_item` method to:
- When deleting replies, specifically identify the HTML element containing the user's own reply by looking for user-specific attributes (username in links/text).
- Search for and click the '...' (caret) button only within the scope of that identified user's reply element.
- If the user's reply cannot be confidently identified, or its menu cannot be found, the item is skipped to prevent errors.
- Slightly improved author verification for quote tweets.